### PR TITLE
画像のみでもメッセージ送信可能となるバリデーションの設定2

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -6,7 +6,7 @@ class Message < ApplicationRecord
   validates :content, presence: true, unless: :was_attached?
   
   def was_attached?
-    self.image.was_attached?
+    self.image.attached?
   end
 
 


### PR DESCRIPTION
#What
画像のみでもメッセージ送信可能となるバリデーションの設定の修正
#Why
画像のみでもメッセージ送信可能となるバリデーションの設定を設定する際に誤って記述していたため